### PR TITLE
Correct captions for Cosmo

### DIFF
--- a/session4/session4.ass
+++ b/session4/session4.ass
@@ -676,50 +676,50 @@ Dialogue: 0,0:43:15.68,0:43:17.28,Default,,0,0,0,,please remember\N to look to s
 Dialogue: 0,0:43:17.28,0:43:21.40,Default,,0,0,0,,there's a Q&A session\N available in your time band
 Dialogue: 0,0:43:21.40,0:43:24.96,Default,,0,0,0,,so that you can discuss\N this work with the author.
 Dialogue: 0,0:43:30.40,0:43:31.92,Default,,0,0,0,,Our next talk\N will be presented
-Dialogue: 0,0:43:31.92,0:43:34.28,Default,,0,0,0,,by Glenn Mevel,\N who will be presenting
-Dialogue: 0,0:43:34.28,0:43:38.60,Default,,0,0,0,,a concurrent separation logic\N for multi-core OCaml.
-Dialogue: 0,0:43:39.80,0:43:42.00,Default,,0,0,0,,GLEN MEVEL: So welcome to this talk,\N I'm Glen Mevel, with
-Dialogue: 0,0:43:42.00,0:43:43.48,Default,,0,0,0,,Jacques-Henri Jourdan\N and Francois Pottier,
-Dialogue: 0,0:43:43.48,0:43:46.32,Default,,0,0,0,,we've been working on\N a concurrent separation logic,
-Dialogue: 0,0:43:46.32,0:43:48.72,Default,,0,0,0,,Multicore OCaml\N What does that mean
-Dialogue: 0,0:43:48.72,0:43:51.84,Default,,0,0,0,,our aim is to verify,\N fine-grained concurrent programs
-Dialogue: 0,0:43:51.84,0:43:53.24,Default,,0,0,0,,in the setting\N of the multicore
+Dialogue: 0,0:43:31.92,0:43:34.28,Default,,0,0,0,,by Glen Mével,\N who will be presenting
+Dialogue: 0,0:43:34.28,0:43:38.60,Default,,0,0,0,,a concurrent separation logic\N for Multicore OCaml.
+Dialogue: 0,0:43:39.80,0:43:42.00,Default,,0,0,0,,GLEN MÉVEL: Welcome to this talk,\N I'm Glen Mével, and with
+Dialogue: 0,0:43:42.00,0:43:43.48,Default,,0,0,0,,Jacques-Henri Jourdan\N and François Pottier,
+Dialogue: 0,0:43:43.48,0:43:46.32,Default,,0,0,0,,we've been working on\N a concurrent separation logic
+Dialogue: 0,0:43:46.32,0:43:48.72,Default,,0,0,0,,for Multicore OCaml\N What does that mean?
+Dialogue: 0,0:43:48.72,0:43:51.84,Default,,0,0,0,,Our aim is to verify,\N fine-grained concurrent programs
+Dialogue: 0,0:43:51.84,0:43:53.24,Default,,0,0,0,,in the setting\N of the Multicore
 Dialogue: 0,0:43:53.24,0:43:57.16,Default,,0,0,0,,OCaml memory model,\N which is a weak memory model.
-Dialogue: 0,0:43:57.16,0:43:59.52,Default,,0,0,0,,In this talk,\N I present a concurrence
+Dialogue: 0,0:43:57.16,0:43:59.52,Default,,0,0,0,,In this talk,\N I present a concurrent
 Dialogue: 0,0:43:59.52,0:44:02.44,Default,,0,0,0,,separation logic\N with a notion of views.
-Dialogue: 0,0:44:04.08,0:44:06.60,Default,,0,0,0,,So if you (INAUDIBLE)\N Multicore Ocaml
-Dialogue: 0,0:44:06.60,0:44:08.88,Default,,0,0,0,,as the name suggests\N it is an extension
+Dialogue: 0,0:44:04.08,0:44:06.60,Default,,0,0,0,,So a few words about\N Multicore Ocaml:
+Dialogue: 0,0:44:06.60,0:44:08.88,Default,,0,0,0,,as the name suggests,\N it is an extension
 Dialogue: 0,0:44:08.88,0:44:10.44,Default,,0,0,0,,of the OCaml\N programming language
-Dialogue: 0,0:44:10.44,0:44:13.12,Default,,0,0,0,,with support\N for Multicore programming,
-Dialogue: 0,0:44:13.12,0:44:16.32,Default,,0,0,0,,it comes with a weak memory model\N which has been formalized
-Dialogue: 0,0:44:16.32,0:44:19.52,Default,,0,0,0,,in the paper PLDI '18,\N and it features
-Dialogue: 0,0:44:19.52,0:44:24.52,Default,,0,0,0,,two flavors of locations\N which are atomic and non-atomic.
+Dialogue: 0,0:44:10.44,0:44:13.12,Default,,0,0,0,,with support\N for multicore programming.
+Dialogue: 0,0:44:13.12,0:44:16.32,Default,,0,0,0,,It comes with a weak memory model\N which has been formalized
+Dialogue: 0,0:44:16.32,0:44:19.52,Default,,0,0,0,,in a paper at PLDI '18,\N and it features
+Dialogue: 0,0:44:19.52,0:44:24.52,Default,,0,0,0,,two flavors of locations\N which are dubbed "atomic" and "non-atomic".
 Dialogue: 0,0:44:25.12,0:44:27.52,Default,,0,0,0,,By the way if you're interested\N in the garbage collector
 Dialogue: 0,0:44:27.52,0:44:29.92,Default,,0,0,0,,of Multicore OCaml,\N please have a look
 Dialogue: 0,0:44:29.92,0:44:32.16,Default,,0,0,0,,at this other ICFP paper, whose title is
 Dialogue: 0,0:44:32.16,0:44:35.52,Default,,0,0,0,,"Retrofitting\N Parallelism onto OCaml."
 Dialogue: 0,0:44:36.40,0:44:38.20,Default,,0,0,0,,So what is the challenge here?
 Dialogue: 0,0:44:38.20,0:44:40.36,Default,,0,0,0,,Essentially, the challenge\N is dealing with
-Dialogue: 0,0:44:40.36,0:44:43.28,Default,,0,0,0,,the weak memory\N and sequential consistency,
+Dialogue: 0,0:44:40.36,0:44:43.28,Default,,0,0,0,,the weak memory.\N Under sequential consistency,
 Dialogue: 0,0:44:43.28,0:44:46.08,Default,,0,0,0,,traditional concurrent\N separation logic
-Dialogue: 0,0:44:46.08,0:44:49.52,Default,,0,0,0,,gives you a (INAUDIBLE),\N x points to V
+Dialogue: 0,0:44:46.08,0:44:49.52,Default,,0,0,0,,gives you a points-to assertion,\N "x points to V"
 Dialogue: 0,0:44:49.52,0:44:51.92,Default,,0,0,0,,which expresses your\N unique ownership
-Dialogue: 0,0:44:51.92,0:44:55.12,Default,,0,0,0,,of the memory location X\N and which also
-Dialogue: 0,0:44:55.12,0:44:58.44,Default,,0,0,0,,says which value\N we started with.
-Dialogue: 0,0:44:58.44,0:45:01.88,Default,,0,0,0,,Then you have the usual\N Hoare style resolving rules.
-Dialogue: 0,0:45:01.88,0:45:04.88,Default,,0,0,0,,And this assertion\N gives you ownership of X
+Dialogue: 0,0:44:51.92,0:44:55.12,Default,,0,0,0,,of the memory location x\N and which also
+Dialogue: 0,0:44:55.12,0:44:58.44,Default,,0,0,0,,says which value\N is stored in x.
+Dialogue: 0,0:44:58.44,0:45:01.88,Default,,0,0,0,,Then you have the usual\N Hoare-style reasoning rules.
+Dialogue: 0,0:45:01.88,0:45:04.88,Default,,0,0,0,,This assertion\N gives you ownership of x
 Dialogue: 0,0:45:04.88,0:45:06.12,Default,,0,0,0,,but you may\N want to share
-Dialogue: 0,0:45:06.12,0:45:08.68,Default,,0,0,0,,this ownership\N and goals, right..
-Dialogue: 0,0:45:08.68,0:45:12.12,Default,,0,0,0,,To do so, And use assertion,\N is to put the assertion,
-Dialogue: 0,0:45:12.12,0:45:14.28,Default,,0,0,0,,in an invariant,
-Dialogue: 0,0:45:14.28,0:45:16.88,Default,,0,0,0,,intuitively an invariant\N holds at all times,
-Dialogue: 0,0:45:16.88,0:45:19.52,Default,,0,0,0,,and it contains\N contents can be accessed equally
+Dialogue: 0,0:45:06.12,0:45:08.68,Default,,0,0,0,,this ownership\N among all threads.
+Dialogue: 0,0:45:08.68,0:45:12.12,Default,,0,0,0,,To do so, an usual solution\N is to put the assertion
+Dialogue: 0,0:45:12.12,0:45:14.28,Default,,0,0,0,,in an invariant.
+Dialogue: 0,0:45:14.28,0:45:16.88,Default,,0,0,0,,Intuitively an invariant\N holds at all times,
+Dialogue: 0,0:45:16.88,0:45:19.52,Default,,0,0,0,,and its contents\N can be accessed equally
 Dialogue: 0,0:45:19.52,0:45:21.32,Default,,0,0,0,,by all threads.
-Dialogue: 0,0:45:21.84,0:45:24.64,Default,,0,0,0,,Here, we can put\N X points to something
-Dialogue: 0,0:45:24.64,0:45:26.92,Default,,0,0,0,,in an invariant\N which we denote
-Dialogue: 0,0:45:26.92,0:45:29.96,Default,,0,0,0,,by boxing the assertion,\N then any thread
-Dialogue: 0,0:45:29.96,0:45:35.36,Default,,0,0,0,,that can access X as long as\N it presents the invariants.
-Dialogue: 0,0:45:35.36,0:45:38.68,Default,,0,0,0,,Now, what breaks\N in the weak memory model
+Dialogue: 0,0:45:21.84,0:45:24.64,Default,,0,0,0,,Here, we can put\N "x points to something"
+Dialogue: 0,0:45:24.64,0:45:26.92,Default,,0,0,0,,in an invariant\N (which we denote
+Dialogue: 0,0:45:26.92,0:45:29.96,Default,,0,0,0,,by boxing the assertion),\N then any thread
+Dialogue: 0,0:45:29.96,0:45:35.36,Default,,0,0,0,,can access x as long as\N it preserves the invariant.
+Dialogue: 0,0:45:35.36,0:45:38.68,Default,,0,0,0,,Now, what breaks\N under a weak memory model
 Dialogue: 0,0:45:38.68,0:45:41.24,Default,,0,0,0,,is that each thread\N now has a different
 Dialogue: 0,0:45:41.24,0:45:43.96,Default,,0,0,0,,view of memory.\N This notion of view
 Dialogue: 0,0:45:43.96,0:45:47.36,Default,,0,0,0,,is crucial, because it means\N that some assertions
@@ -727,263 +727,263 @@ Dialogue: 0,0:45:47.36,0:45:50.56,Default,,0,0,0,,like the points-to assertion\N
 Dialogue: 0,0:45:50.56,0:45:53.64,Default,,0,0,0,,with respect\N to the current view of a thread.
 Dialogue: 0,0:45:53.64,0:45:56.24,Default,,0,0,0,,We call these kinds\N of assertions
 Dialogue: 0,0:45:56.24,0:46:00.64,Default,,0,0,0,,subjective assertions.\N But on the other hand,
-Dialogue: 0,0:46:00.64,0:46:03.32,Default,,0,0,0,,invariants hold\N equality for all threads,
+Dialogue: 0,0:46:00.64,0:46:03.32,Default,,0,0,0,,invariants hold\N equally for all threads,
 Dialogue: 0,0:46:03.32,0:46:05.96,Default,,0,0,0,,so they can only contain\N objective assertions
 Dialogue: 0,0:46:05.96,0:46:11.08,Default,,0,0,0,,where by objective\N we mean non-subjective.
-Dialogue: 0,0:46:11.08,0:46:14.20,Default,,0,0,0,,Then the challenge\N is to give a program logic,
-Dialogue: 0,0:46:14.20,0:46:16.88,Default,,0,0,0,,which felt simple\N and natural enough
-Dialogue: 0,0:46:16.88,0:46:18.96,Default,,0,0,0,,that at the same time\N is able to deal
-Dialogue: 0,0:46:18.96,0:46:21.16,Default,,0,0,0,,with subjectivity\N on the laws
-Dialogue: 0,0:46:21.16,0:46:24.32,Default,,0,0,0,,subject assertions\N to be shared, between threads.
-Dialogue: 0,0:46:26.80,0:46:30.04,Default,,0,0,0,,I just spoke about the view\N of a thread on how it is
+Dialogue: 0,0:46:11.08,0:46:14.20,Default,,0,0,0,,Then the challenge\N is to keep a program logic
+Dialogue: 0,0:46:14.20,0:46:16.88,Default,,0,0,0,,which feels simple\N and natural enough
+Dialogue: 0,0:46:16.88,0:46:18.96,Default,,0,0,0,,but at the same time\N is able to deal
+Dialogue: 0,0:46:18.96,0:46:21.16,Default,,0,0,0,,with subjectivity,\N and allows
+Dialogue: 0,0:46:21.16,0:46:24.32,Default,,0,0,0,,subjective assertions\N to be shared between threads.
+Dialogue: 0,0:46:26.80,0:46:30.04,Default,,0,0,0,,I just spoke about the view\N of a thread and how it is
 Dialogue: 0,0:46:30.04,0:46:33.08,Default,,0,0,0,,central to the challenge\N of weak memory,
-Dialogue: 0,0:46:33.08,0:46:34.96,Default,,0,0,0,,but I haven't defined\N this concept yet.
-Dialogue: 0,0:46:34.96,0:46:38.36,Default,,0,0,0,,So let me do that now,\N because of weak memory
-Dialogue: 0,0:46:38.36,0:46:41.20,Default,,0,0,0,,each thread only know\N the subset of all writes
+Dialogue: 0,0:46:33.08,0:46:34.96,Default,,0,0,0,,but I haven't defined\N this concept yet,
+Dialogue: 0,0:46:34.96,0:46:38.36,Default,,0,0,0,,so let me do that now.\N Because of weak memory
+Dialogue: 0,0:46:38.36,0:46:41.20,Default,,0,0,0,,each thread only knows\N a subset of all writes
 Dialogue: 0,0:46:41.20,0:46:44.00,Default,,0,0,0,,that have happened\N to the shared memory.
-Dialogue: 0,0:46:44.00,0:46:48.12,Default,,0,0,0,,This affects how the threads\N how the thread reads
-Dialogue: 0,0:46:48.12,0:46:50.44,Default,,0,0,0,,or writes the memory,\N for example
-Dialogue: 0,0:46:50.44,0:46:53.12,Default,,0,0,0,,once it has learned\N about the writes,
+Dialogue: 0,0:46:44.00,0:46:48.12,Default,,0,0,0,,This affects how\N a thread reads
+Dialogue: 0,0:46:48.12,0:46:50.44,Default,,0,0,0,,and writes the memory.\N For example,
+Dialogue: 0,0:46:50.44,0:46:53.12,Default,,0,0,0,,once it has learned\N about a write,
 Dialogue: 0,0:46:53.12,0:46:56.44,Default,,0,0,0,,it cannot read\N from earlier writes anymore.
 Dialogue: 0,0:46:56.44,0:46:58.36,Default,,0,0,0,,This is an example\N of what a weak
-Dialogue: 0,0:46:58.36,0:47:03.88,Default,,0,0,0,,memory model would say U,\N and this subset of write events,
-Dialogue: 0,0:47:03.88,0:47:06.12,Default,,0,0,0,,we will call it a view,\N so the view of a thread
-Dialogue: 0,0:47:06.12,0:47:09.44,Default,,0,0,0,,of the view of a thread\N is the set of
-Dialogue: 0,0:47:09.44,0:47:12.48,Default,,0,0,0,,of the write events\N it knows about.
-Dialogue: 0,0:47:13.36,0:47:17.04,Default,,0,0,0,,Now, we want to manipulate\N these views from logic.
-Dialogue: 0,0:47:17.04,0:47:20.80,Default,,0,0,0,,For that, we have new\N kinds of assertions.
+Dialogue: 0,0:46:58.36,0:47:03.88,Default,,0,0,0,,memory model would say you.\N And this subset of write events,
+Dialogue: 0,0:47:03.88,0:47:06.12,Default,,0,0,0,,we will call it a view.\N So the view of a thread
+Dialogue: 0,0:47:06.12,0:47:09.44,Default,,0,0,0,,is the set of\N write events it knows about.
+Dialogue: 0,0:47:09.44,0:47:12.48,Default,,0,0,0,,is the set of\N write events it knows about.
+Dialogue: 0,0:47:13.36,0:47:17.04,Default,,0,0,0,,Now, we want to manipulate\N these views from the logic.
+Dialogue: 0,0:47:17.04,0:47:20.80,Default,,0,0,0,,For that, we add new\N kinds of assertions.
 Dialogue: 0,0:47:20.80,0:47:22.88,Default,,0,0,0,,The first new kind\N of assertions is
-Dialogue: 0,0:47:22.88,0:47:25.88,Default,,0,0,0,,this upper view where\N U is a view,
-Dialogue: 0,0:47:25.88,0:47:28.96,Default,,0,0,0,,we pronounce it\N as we have seen U,
-Dialogue: 0,0:47:28.96,0:47:30.84,Default,,0,0,0,,but it means that\N the current thread
-Dialogue: 0,0:47:30.84,0:47:32.96,Default,,0,0,0,,knows all writes\N and U is an assertion
+Dialogue: 0,0:47:22.88,0:47:25.88,Default,,0,0,0,,this "up-arrow U"\N where U is a view,
+Dialogue: 0,0:47:25.88,0:47:28.96,Default,,0,0,0,,we pronounce it\N as "we have seen U",
+Dialogue: 0,0:47:28.96,0:47:30.84,Default,,0,0,0,,and it means that\N the current thread
+Dialogue: 0,0:47:30.84,0:47:32.96,Default,,0,0,0,,knows all writes in U.\N So it is an assertion
 Dialogue: 0,0:47:32.96,0:47:36.44,Default,,0,0,0,,about the current view\N of the thread.
-Dialogue: 0,0:47:37.00,0:47:39.80,Default,,0,0,0,,And the second\N new session is P at U,
-Dialogue: 0,0:47:39.80,0:47:42.08,Default,,0,0,0,,were P\N in an assertion,
-Dialogue: 0,0:47:42.08,0:47:46.04,Default,,0,0,0,,and U is a view\N it means that P holds in the eyes
+Dialogue: 0,0:47:37.00,0:47:39.80,Default,,0,0,0,,The second\N new assertion is "P at U",
+Dialogue: 0,0:47:39.80,0:47:42.08,Default,,0,0,0,,where P\N is an assertion
+Dialogue: 0,0:47:42.08,0:47:46.04,Default,,0,0,0,,and U is a view.\N It means that P holds in the eyes
 Dialogue: 0,0:47:46.04,0:47:48.92,Default,,0,0,0,,of any thread\N which has seen U.
 Dialogue: 0,0:47:48.92,0:47:52.28,Default,,0,0,0,,For example, let's say\N that P relies
 Dialogue: 0,0:47:52.28,0:47:54.52,Default,,0,0,0,,on knowing\N a given write event.
 Dialogue: 0,0:47:54.52,0:47:58.20,Default,,0,0,0,,Then it requires the current view\N to contain that write event.
-Dialogue: 0,0:47:58.20,0:48:01.80,Default,,0,0,0,,(INAUDIBLE) subjective.
-Dialogue: 0,0:48:01.80,0:48:04.24,Default,,0,0,0,,But instead we're going to\N (INAUDIBLE)
+Dialogue: 0,0:47:58.20,0:48:01.80,Default,,0,0,0,,So asserting P is subjective.
+Dialogue: 0,0:48:01.80,0:48:04.24,Default,,0,0,0,,But instead we're going to\N say that whatever
 Dialogue: 0,0:48:04.24,0:48:06.76,Default,,0,0,0,,the current view is,\N if it contains
 Dialogue: 0,0:48:06.76,0:48:10.16,Default,,0,0,0,,that write event,\N then P holds.
-Dialogue: 0,0:48:10.16,0:48:14.24,Default,,0,0,0,,And I say these, we do not\N depend anymore on the current view.
+Dialogue: 0,0:48:10.16,0:48:14.24,Default,,0,0,0,,And by saying this, we do not\N depend anymore on the current view.
 Dialogue: 0,0:48:14.24,0:48:18.32,Default,,0,0,0,,So saying this is objective,\N even though P
-Dialogue: 0,0:48:18.32,0:48:21.24,Default,,0,0,0,,maybe subjective.\N And that's what
-Dialogue: 0,0:48:21.24,0:48:26.24,Default,,0,0,0,,the @U means when\N U contains the given write events.
-Dialogue: 0,0:48:28.84,0:48:30.84,Default,,0,0,0,,So we can make\N a subjective assertions objective
+Dialogue: 0,0:48:18.32,0:48:21.24,Default,,0,0,0,,may be subjective.\N And that's what
+Dialogue: 0,0:48:21.24,0:48:26.24,Default,,0,0,0,,"P at U" means when\N U contains the given write event.
+Dialogue: 0,0:48:28.84,0:48:30.84,Default,,0,0,0,,So we can make\N a subjective assertion objective
 Dialogue: 0,0:48:30.84,0:48:35.84,Default,,0,0,0,,by specifying the view\N at which we see it.
-Dialogue: 0,0:48:37.56,0:48:39.72,Default,,0,0,0,,On the way\N U is interesting
-Dialogue: 0,0:48:39.72,0:48:43.08,Default,,0,0,0,,because these new\N assertions, complementary,
-Dialogue: 0,0:48:43.08,0:48:47.08,Default,,0,0,0,,or precisely in a logic\N an assertion P
-Dialogue: 0,0:48:47.08,0:48:49.16,Default,,0,0,0,,is equivalent\N to an objective,
-Dialogue: 0,0:48:49.16,0:48:51.96,Default,,0,0,0,,assertion, any assertion\N is equivalent
-Dialogue: 0,0:48:51.96,0:48:55.32,Default,,0,0,0,,to an objective assertion\N of the form P at U
-Dialogue: 0,0:48:55.32,0:48:58.48,Default,,0,0,0,,and a assertion of the form,\N upper U,
+Dialogue: 0,0:48:37.56,0:48:39.72,Default,,0,0,0,,And why is it\N interesting?
+Dialogue: 0,0:48:39.72,0:48:43.08,Default,,0,0,0,,Because these new\N assertions are complementary.
+Dialogue: 0,0:48:43.08,0:48:47.08,Default,,0,0,0,,More precisely, in our logic,\N any assertion P
+Dialogue: 0,0:48:47.08,0:48:49.16,Default,,0,0,0,,is equivalent
+Dialogue: 0,0:48:49.16,0:48:51.96,Default,,0,0,0,,to an objective assertion\N of the form "P at U",
+Dialogue: 0,0:48:51.96,0:48:55.32,Default,,0,0,0,,to an objective assertion\N of the form "P at U",
+Dialogue: 0,0:48:55.32,0:48:58.48,Default,,0,0,0,,and a assertion of the form,\N "up-arrow U",
 Dialogue: 0,0:48:58.48,0:49:02.64,Default,,0,0,0,,for some view U.\N This shows in particular
-Dialogue: 0,0:49:02.64,0:49:06.32,Default,,0,0,0,,that your assertions\N of the form upper U.
-Dialogue: 0,0:49:06.32,0:49:08.76,Default,,0,0,0,,Capture all the\N subjectivity of the,
-Dialogue: 0,0:49:08.76,0:49:12.24,Default,,0,0,0,,all the subjectivity\N of the weak memory.
-Dialogue: 0,0:49:12.76,0:49:16.96,Default,,0,0,0,,And this decomposition, will allow us\N to share subjective assertions,
-Dialogue: 0,0:49:16.96,0:49:19.32,Default,,0,0,0,,but in Threads, by using\N a different mechanism for each part.
-Dialogue: 0,0:49:22.44,0:49:24.48,Default,,0,0,0,,The first part P@U,
+Dialogue: 0,0:49:02.64,0:49:06.32,Default,,0,0,0,,that view assertions\N of the form "up-arrow U"
+Dialogue: 0,0:49:06.32,0:49:08.76,Default,,0,0,0,,capture all the\N subjectivity of the
+Dialogue: 0,0:49:08.76,0:49:12.24,Default,,0,0,0,,weak memory.
+Dialogue: 0,0:49:12.76,0:49:16.96,Default,,0,0,0,,And this decomposition will allow us\N to share subjective assertions
+Dialogue: 0,0:49:16.96,0:49:19.32,Default,,0,0,0,,between threads, by using\N a different mechanism for each part.
+Dialogue: 0,0:49:22.44,0:49:24.48,Default,,0,0,0,,The first part, "P at U",
 Dialogue: 0,0:49:24.48,0:49:25.32,Default,,0,0,0,,is objective
-Dialogue: 0,0:49:25.32,0:49:27.72,Default,,0,0,0,,so it can be shared by an invariant,
-Dialogue: 0,0:49:27.72,0:49:29.44,Default,,0,0,0,,via an invariant,
-Dialogue: 0,0:49:29.44,0:49:33.60,Default,,0,0,0,,just as in usual\N concurrent separation logic.
-Dialogue: 0,0:49:33.60,0:49:35.08,Default,,0,0,0,,Regarding the second parts,
-Dialogue: 0,0:49:35.08,0:49:37.08,Default,,0,0,0,,sharing upper U,
+Dialogue: 0,0:49:25.32,0:49:27.72,Default,,0,0,0,,so it can be shared via an invariant,
+Dialogue: 0,0:49:27.72,0:49:29.44,Default,,0,0,0,,so it can be shared via an invariant,
+Dialogue: 0,0:49:29.44,0:49:33.60,Default,,0,0,0,,just as in usual\N concurrent separation logics.
+Dialogue: 0,0:49:33.60,0:49:35.08,Default,,0,0,0,,Regarding the second part,
+Dialogue: 0,0:49:35.08,0:49:37.08,Default,,0,0,0,,sharing "up-arrow U"
 Dialogue: 0,0:49:37.08,0:49:38.96,Default,,0,0,0,,means exchanging information
-Dialogue: 0,0:49:38.96,0:49:41.20,Default,,0,0,0,,about write events into threads.
+Dialogue: 0,0:49:38.96,0:49:41.20,Default,,0,0,0,,about write events between threads.
 Dialogue: 0,0:49:41.20,0:49:42.04,Default,,0,0,0,,So in other words,
 Dialogue: 0,0:49:42.04,0:49:44.32,Default,,0,0,0,,it means synchronizing.
-Dialogue: 0,0:49:44.32,0:49:48.20,Default,,0,0,0,,So we will rely on some form\N of thread synchronization,
+Dialogue: 0,0:49:44.32,0:49:48.20,Default,,0,0,0,,So we will rely on some form\N of thread synchronization
 Dialogue: 0,0:49:48.20,0:49:50.72,Default,,0,0,0,,that is provided by the memory model.
 Dialogue: 0,0:49:53.32,0:49:55.64,Default,,0,0,0,,That was the main idea of this talk.
 Dialogue: 0,0:49:55.64,0:49:59.56,Default,,0,0,0,,Now I show you what is\N in our program logic,
-Dialogue: 0,0:49:59.56,0:50:01.44,Default,,0,0,0,,to reason about program and memory,
+Dialogue: 0,0:49:59.56,0:50:01.44,Default,,0,0,0,,to reason about programs and memory,
 Dialogue: 0,0:50:01.44,0:50:03.20,Default,,0,0,0,,and I'll start with the simplest thing,
 Dialogue: 0,0:50:03.20,0:50:05.52,Default,,0,0,0,,which are atomic locations.
 Dialogue: 0,0:50:06.68,0:50:07.88,Default,,0,0,0,,For atomic locations,
-Dialogue: 0,0:50:07.88,0:50:10.52,Default,,0,0,0,,we have a neutral looking\N points-to assertion,
-Dialogue: 0,0:50:11.92,0:50:13.68,Default,,0,0,0,,atomic x points to v,
-Dialogue: 0,0:50:13.68,0:50:15.16,Default,,0,0,0,,which means that (INAUDIBLE)
+Dialogue: 0,0:50:07.88,0:50:10.52,Default,,0,0,0,,we have an usual-looking\N points-to assertion,
+Dialogue: 0,0:50:11.92,0:50:13.68,Default,,0,0,0,,"atomic x points to v",
+Dialogue: 0,0:50:13.68,0:50:15.16,Default,,0,0,0,,which means that we own the
 Dialogue: 0,0:50:15.16,0:50:17.08,Default,,0,0,0,,atomic location x,
 Dialogue: 0,0:50:17.08,0:50:18.60,Default,,0,0,0,,and x stores the value v.
 Dialogue: 0,0:50:20.40,0:50:22.68,Default,,0,0,0,,We are able to say such a thing,
-Dialogue: 0,0:50:22.68,0:50:25.68,Default,,0,0,0,,because atomic locations behave
-Dialogue: 0,0:50:25.68,0:50:28.04,Default,,0,0,0,,in a sequentially consistent way.
+Dialogue: 0,0:50:22.68,0:50:25.68,Default,,0,0,0,,because atomic locations\N in Multicore OCaml
+Dialogue: 0,0:50:25.68,0:50:28.04,Default,,0,0,0,,behave in a sequentially consistent way.
 Dialogue: 0,0:50:28.04,0:50:29.12,Default,,0,0,0,,At any given time,
 Dialogue: 0,0:50:29.12,0:50:31.92,Default,,0,0,0,,all threads see the same value for x.
 Dialogue: 0,0:50:33.48,0:50:34.84,Default,,0,0,0,,In particular,
-Dialogue: 0,0:50:34.84,0:50:36.52,Default,,0,0,0,,this assertion is subjective,
-Dialogue: 0,0:50:37.48,0:50:39.32,Default,,0,0,0,,they should come as no surprise,
-Dialogue: 0,0:50:39.32,0:50:42.00,Default,,0,0,0,,that atomic x's are by the usual,
-Dialogue: 0,0:50:42.00,0:50:45.36,Default,,0,0,0,,Hoare triples both reads and writes.
+Dialogue: 0,0:50:34.84,0:50:36.52,Default,,0,0,0,,this assertion is objective,
+Dialogue: 0,0:50:37.48,0:50:39.32,Default,,0,0,0,,then it should come as no surprise
+Dialogue: 0,0:50:39.32,0:50:42.00,Default,,0,0,0,,that atomic accesses obey the usual
+Dialogue: 0,0:50:42.00,0:50:45.36,Default,,0,0,0,,Hoare triples, both reads and writes.
 Dialogue: 0,0:50:48.28,0:50:49.76,Default,,0,0,0,,Where things become interesting,
 Dialogue: 0,0:50:49.76,0:50:51.80,Default,,0,0,0,,is for non-atomic locations.
-Dialogue: 0,0:50:51.80,0:50:53.52,Default,,0,0,0,,The non-atomic locations of particular
-Dialogue: 0,0:50:53.52,0:50:55.96,Default,,0,0,0,,OCaml have relaxed behavior.
-Dialogue: 0,0:50:57.04,0:51:00.28,Default,,0,0,0,,In a logic we still have\N an assertion x points to v,
+Dialogue: 0,0:50:51.80,0:50:53.52,Default,,0,0,0,,The non-atomic locations of Multicore
+Dialogue: 0,0:50:53.52,0:50:55.96,Default,,0,0,0,,OCaml have a relaxed behavior.
+Dialogue: 0,0:50:57.04,0:51:00.28,Default,,0,0,0,,In our logic we still have\N an assertion "x points to v",
 Dialogue: 0,0:51:00.28,0:51:02.44,Default,,0,0,0,,with its meaning differ slightly.
-Dialogue: 0,0:51:02.44,0:51:04.20,Default,,0,0,0,,It still asserts the (INAUDIBLE) of x,
-Dialogue: 0,0:51:04.20,0:51:05.80,Default,,0,0,0,,but instead of saying that,
+Dialogue: 0,0:51:02.44,0:51:04.20,Default,,0,0,0,,It still asserts the ownership of x,
+Dialogue: 0,0:51:04.20,0:51:05.80,Default,,0,0,0,,but instead of saying that
 Dialogue: 0,0:51:06.64,0:51:08.16,Default,,0,0,0,,the value of x is v,
-Dialogue: 0,0:51:08.16,0:51:11.36,Default,,0,0,0,,it says that we have seen\N the (INAUDIBLE) to x,
+Dialogue: 0,0:51:08.16,0:51:11.36,Default,,0,0,0,,it says that we have seen\N the latest write to x,
 Dialogue: 0,0:51:11.36,0:51:13.04,Default,,0,0,0,,and this write bears the value v.
 Dialogue: 0,0:51:14.32,0:51:17.88,Default,,0,0,0,,And this is the typical\N subjective assertion.
 Dialogue: 0,0:51:17.88,0:51:19.36,Default,,0,0,0,,There is no such a thing as
 Dialogue: 0,0:51:19.36,0:51:21.24,Default,,0,0,0,,the global value of x,
 Dialogue: 0,0:51:21.24,0:51:24.36,Default,,0,0,0,,because different threads\N do not necessarily know
 Dialogue: 0,0:51:24.36,0:51:25.80,Default,,0,0,0,,about the same writes to x.
-Dialogue: 0,0:51:28.84,0:51:31.72,Default,,0,0,0,,What is really nice with\N this points to assertion ,
+Dialogue: 0,0:51:28.84,0:51:31.72,Default,,0,0,0,,What is really nice with\N this points-to assertion,
 Dialogue: 0,0:51:31.72,0:51:34.24,Default,,0,0,0,,is that it also obeys the standard rules.
-Dialogue: 0,0:51:34.24,0:51:37.92,Default,,0,0,0,,So we have a simple looking assertion,
+Dialogue: 0,0:51:34.24,0:51:37.92,Default,,0,0,0,,So we have a simple looking assertion
 Dialogue: 0,0:51:37.92,0:51:39.72,Default,,0,0,0,,that behaves in a natural way,
-Dialogue: 0,0:51:39.72,0:51:42.76,Default,,0,0,0,,and the price for it\N is that the assertion,
-Dialogue: 0,0:51:42.76,0:51:47.04,Default,,0,0,0,,hides more (INAUDIBLE) it is subjective.
-Dialogue: 0,0:51:47.04,0:51:48.24,Default,,0,0,0,,So we cannot share it,
+Dialogue: 0,0:51:39.72,0:51:42.76,Default,,0,0,0,,but the price for it\N is that the assertion
+Dialogue: 0,0:51:42.76,0:51:47.04,Default,,0,0,0,,hides more behind the scenes\N and it is subjective.
+Dialogue: 0,0:51:47.04,0:51:48.24,Default,,0,0,0,,So we cannot share it
 Dialogue: 0,0:51:48.24,0:51:50.48,Default,,0,0,0,,only by using an invariant.
-Dialogue: 0,0:51:52.48,0:51:54.44,Default,,0,0,0,,So let's see how we can share it none
-Dialogue: 0,0:51:54.44,0:51:56.32,Default,,0,0,0,,the less and for that,
-Dialogue: 0,0:51:56.32,0:51:58.52,Default,,0,0,0,,let's consider the typical lock pattern,
+Dialogue: 0,0:51:52.48,0:51:54.44,Default,,0,0,0,,So let's see how\N we can share it nonetheless,
+Dialogue: 0,0:51:54.44,0:51:56.32,Default,,0,0,0,,and for that,
+Dialogue: 0,0:51:56.32,0:51:58.52,Default,,0,0,0,,let's consider that typical code pattern
 Dialogue: 0,0:51:58.52,0:51:59.92,Default,,0,0,0,,which is called a spin lock.
 Dialogue: 0,0:52:01.60,0:52:03.32,Default,,0,0,0,,Let's say we have several threads,
 Dialogue: 0,0:52:03.32,0:52:05.20,Default,,0,0,0,,that want to access the same resource,
-Dialogue: 0,0:52:05.20,0:52:08.44,Default,,0,0,0,,such as a single monotone location.
-Dialogue: 0,0:52:08.44,0:52:11.00,Default,,0,0,0,,Then we can use an atomic\N flag to guard a resource,
+Dialogue: 0,0:52:05.20,0:52:08.44,Default,,0,0,0,,such as a single non-atomic location.
+Dialogue: 0,0:52:08.44,0:52:11.00,Default,,0,0,0,,Then we can use an atomic\N flag to guard that resource:
 Dialogue: 0,0:52:11.00,0:52:12.20,Default,,0,0,0,,when the flag is true,
 Dialogue: 0,0:52:12.20,0:52:13.36,Default,,0,0,0,,the resource is taken,
 Dialogue: 0,0:52:13.36,0:52:14.92,Default,,0,0,0,,and if you want to acquire it,
 Dialogue: 0,0:52:14.92,0:52:17.64,Default,,0,0,0,,you need to wait for\N it to become available.
 Dialogue: 0,0:52:17.64,0:52:19.52,Default,,0,0,0,,Now from a logical point of view,
 Dialogue: 0,0:52:19.52,0:52:22.92,Default,,0,0,0,,the lock can be seen as\N guarding an assertion P,
-Dialogue: 0,0:52:22.92,0:52:24.08,Default,,0,0,0,,which means subjective,
+Dialogue: 0,0:52:22.92,0:52:24.08,Default,,0,0,0,,which may be subjective,
 Dialogue: 0,0:52:24.08,0:52:24.92,Default,,0,0,0,,for example,
-Dialogue: 0,0:52:24.92,0:52:26.72,Default,,0,0,0,,it may be another\N points to assertion,
-Dialogue: 0,0:52:26.72,0:52:28.68,Default,,0,0,0,,as we've seen before.
-Dialogue: 0,0:52:28.68,0:52:30.76,Default,,0,0,0,,The first thread has P,
+Dialogue: 0,0:52:24.92,0:52:26.72,Default,,0,0,0,,it may be a non-atomic\N points-to assertion,
+Dialogue: 0,0:52:26.72,0:52:28.68,Default,,0,0,0,,as evoked just before.
+Dialogue: 0,0:52:28.68,0:52:30.76,Default,,0,0,0,,The first thread has P
 Dialogue: 0,0:52:30.76,0:52:32.52,Default,,0,0,0,,before releasing the lock.
 Dialogue: 0,0:52:32.52,0:52:36.40,Default,,0,0,0,,The second thread will get P\N after it has acquired the lock.
-Dialogue: 0,0:52:36.40,0:52:38.92,Default,,0,0,0,,So we want P to be transferred,
+Dialogue: 0,0:52:36.40,0:52:38.92,Default,,0,0,0,,So we want P to be transferred
 Dialogue: 0,0:52:38.92,0:52:41.76,Default,,0,0,0,,from the first thread to the second one.
 Dialogue: 0,0:52:43.12,0:52:44.48,Default,,0,0,0,,To see how that works,
-Dialogue: 0,0:52:44.48,0:52:45.92,Default,,0,0,0,,let's consider,
-Dialogue: 0,0:52:45.92,0:52:48.64,Default,,0,0,0,,I'll need a comprehensive\N operation that exists,
+Dialogue: 0,0:52:44.48,0:52:45.92,Default,,0,0,0,,let's consider
+Dialogue: 0,0:52:45.92,0:52:48.64,Default,,0,0,0,,only the compare-and-set\N operation that succeeds,
 Dialogue: 0,0:52:48.64,0:52:51.84,Default,,0,0,0,,because that's when the transfer happens.
-Dialogue: 0,0:52:53.40,0:52:56.28,Default,,0,0,0,,As we've seen we decompose\N P to an objective part,
+Dialogue: 0,0:52:53.40,0:52:56.28,Default,,0,0,0,,As we've seen we decompose\N P into an objective part
 Dialogue: 0,0:52:56.28,0:52:57.60,Default,,0,0,0,,and a subjective part,
 Dialogue: 0,0:52:57.60,0:52:59.36,Default,,0,0,0,,so that we can transfer each part.
-Dialogue: 0,0:53:00.28,0:53:03.68,Default,,0,0,0,,The first part P@U is objective.
-Dialogue: 0,0:53:03.68,0:53:06.44,Default,,0,0,0,,So it can be transferred\N using an invariant as before.
+Dialogue: 0,0:53:00.28,0:53:03.68,Default,,0,0,0,,The first part, "P at U", is objective.
+Dialogue: 0,0:53:03.68,0:53:06.44,Default,,0,0,0,,So it can be transferred\N using an invariant as usual.
 Dialogue: 0,0:53:06.44,0:53:08.04,Default,,0,0,0,,So we get rid of it.
 Dialogue: 0,0:53:08.04,0:53:10.12,Default,,0,0,0,,So now we are down to the problem
-Dialogue: 0,0:53:10.12,0:53:12.20,Default,,0,0,0,,of transferring up U assertion.
+Dialogue: 0,0:53:10.12,0:53:12.20,Default,,0,0,0,,of transferring a view assertion.
 Dialogue: 0,0:53:14.16,0:53:15.04,Default,,0,0,0,,As I said before,
-Dialogue: 0,0:53:15.04,0:53:17.64,Default,,0,0,0,,we need some form of\N synchronization on here.
-Dialogue: 0,0:53:17.64,0:53:19.00,Default,,0,0,0,,What OCaml gives us,
-Dialogue: 0,0:53:19.00,0:53:21.16,Default,,0,0,0,,is a happens-before relationship,
-Dialogue: 0,0:53:21.16,0:53:24.52,Default,,0,0,0,,from the releasing write\N to the acquired read.
+Dialogue: 0,0:53:15.04,0:53:17.64,Default,,0,0,0,,we need some form of\N synchronization and, here,
+Dialogue: 0,0:53:17.64,0:53:19.00,Default,,0,0,0,,What Multicore OCaml gives us
+Dialogue: 0,0:53:19.00,0:53:21.16,Default,,0,0,0,,is a happens-before relationship
+Dialogue: 0,0:53:21.16,0:53:24.52,Default,,0,0,0,,from the release write\N to the acquire read.
 Dialogue: 0,0:53:24.52,0:53:27.44,Default,,0,0,0,,So instead of adding\N new primitives to the language,
-Dialogue: 0,0:53:27.44,0:53:29.08,Default,,0,0,0,,multicore OCaml made the choice
-Dialogue: 0,0:53:29.08,0:53:32.36,Default,,0,0,0,,of performing release-acquire\N synchronization on atomic access.
-Dialogue: 0,0:53:34.32,0:53:37.04,Default,,0,0,0,,And we need to reflect\N this in our program logic,
-Dialogue: 0,0:53:37.04,0:53:38.72,Default,,0,0,0,,and we do so,
-Dialogue: 0,0:53:38.72,0:53:40.92,Default,,0,0,0,,by extending the atomic\N points to predicate.
-Dialogue: 0,0:53:43.28,0:53:46.76,Default,,0,0,0,,So recall that atomic points to v,
-Dialogue: 0,0:53:46.76,0:53:48.76,Default,,0,0,0,,means that x stores the value of v.
-Dialogue: 0,0:53:50.56,0:53:52.20,Default,,0,0,0,,We know what's done this assertion.
-Dialogue: 0,0:53:52.20,0:53:55.08,Default,,0,0,0,,So that atomic locations stores the pair
-Dialogue: 0,0:53:55.96,0:53:57.16,Default,,0,0,0,,of the value and a view,
-Dialogue: 0,0:53:59.60,0:54:02.00,Default,,0,0,0,,so accesses still behave the same,
-Dialogue: 0,0:54:02.00,0:54:04.04,Default,,0,0,0,,with respect to the view value,
-Dialogue: 0,0:54:04.96,0:54:08.92,Default,,0,0,0,,but they also perform a\N release acquire synchronization
+Dialogue: 0,0:53:27.44,0:53:29.08,Default,,0,0,0,,Multicore OCaml made the choice
+Dialogue: 0,0:53:29.08,0:53:32.36,Default,,0,0,0,,of performing release/acquire\N synchronization on atomic access.
+Dialogue: 0,0:53:34.32,0:53:37.04,Default,,0,0,0,,We need to reflect\N this in our program logic,
+Dialogue: 0,0:53:37.04,0:53:38.72,Default,,0,0,0,,and we do so
+Dialogue: 0,0:53:38.72,0:53:40.92,Default,,0,0,0,,by extending the atomic\N points-to predicate.
+Dialogue: 0,0:53:43.28,0:53:46.76,Default,,0,0,0,,So recall that "atomic points to v"
+Dialogue: 0,0:53:46.76,0:53:48.76,Default,,0,0,0,,means that x stores the value v.
+Dialogue: 0,0:53:50.56,0:53:52.20,Default,,0,0,0,,We now extend this assertion,
+Dialogue: 0,0:53:52.20,0:53:55.08,Default,,0,0,0,,so that an atomic location stores the pair
+Dialogue: 0,0:53:55.96,0:53:57.16,Default,,0,0,0,,of a value and a view.
+Dialogue: 0,0:53:59.60,0:54:02.00,Default,,0,0,0,,So accesses still behave the same
+Dialogue: 0,0:54:02.00,0:54:04.04,Default,,0,0,0,,with respect to the value,
+Dialogue: 0,0:54:04.96,0:54:08.92,Default,,0,0,0,,but they also perform a\N release/acquire synchronization
 Dialogue: 0,0:54:08.92,0:54:09.76,Default,,0,0,0,,on the view.
 Dialogue: 0,0:54:11.40,0:54:12.92,Default,,0,0,0,,So when writing,
 Dialogue: 0,0:54:12.92,0:54:15.20,Default,,0,0,0,,we push into the shared location,
 Dialogue: 0,0:54:15.20,0:54:17.96,Default,,0,0,0,,any information we have in the local view.
 Dialogue: 0,0:54:17.96,0:54:20.20,Default,,0,0,0,,So that's a release write.
 Dialogue: 0,0:54:20.20,0:54:21.40,Default,,0,0,0,,And conversely,
-Dialogue: 0,0:54:21.40,0:54:25.44,Default,,0,0,0,,when reading we pull into a local view,
-Dialogue: 0,0:54:25.44,0:54:28.48,Default,,0,0,0,,any information stored\N in a shared location.
+Dialogue: 0,0:54:21.40,0:54:25.44,Default,,0,0,0,,when reading, we pull into our local view
+Dialogue: 0,0:54:25.44,0:54:28.48,Default,,0,0,0,,any information stored\N in the shared location.
 Dialogue: 0,0:54:28.48,0:54:29.72,Default,,0,0,0,,So that's an acquire read.
 Dialogue: 0,0:54:32.00,0:54:33.04,Default,,0,0,0,,And with this in mind,
 Dialogue: 0,0:54:33.04,0:54:34.68,Default,,0,0,0,,let's come back to our spin lock.
 Dialogue: 0,0:54:36.32,0:54:37.64,Default,,0,0,0,,As we have seen before,
 Dialogue: 0,0:54:37.64,0:54:40.08,Default,,0,0,0,,the spin lock has two operations,
-Dialogue: 0,0:54:40.08,0:54:41.96,Default,,0,0,0,,release and acquire,
-Dialogue: 0,0:54:41.96,0:54:44.88,Default,,0,0,0,,in the interface (INAUDIBLE) assertion P,
-Dialogue: 0,0:54:44.88,0:54:47.20,Default,,0,0,0,,we give the spin lock a specification,
-Dialogue: 0,0:54:47.20,0:54:49.80,Default,,0,0,0,,which holds under some invariant,
-Dialogue: 0,0:54:49.80,0:54:50.88,Default,,0,0,0,,and now,
-Dialogue: 0,0:54:50.88,0:54:55.08,Default,,0,0,0,,to put this specification in\N the usual separation logic,
+Dialogue: 0,0:54:40.08,0:54:41.96,Default,,0,0,0,,release and acquire.
+Dialogue: 0,0:54:41.96,0:54:44.88,Default,,0,0,0,,In the interface it guards an assertion P.
+Dialogue: 0,0:54:44.88,0:54:47.20,Default,,0,0,0,,We give the spin lock a specification,
+Dialogue: 0,0:54:47.20,0:54:49.80,Default,,0,0,0,,which holds under some invariant.
+Dialogue: 0,0:54:49.80,0:54:50.88,Default,,0,0,0,,And now,
+Dialogue: 0,0:54:50.88,0:54:55.08,Default,,0,0,0,,to prove this specification in\N the usual separation logic,
 Dialogue: 0,0:54:56.16,0:54:57.64,Default,,0,0,0,,with sequential consistency,
-Dialogue: 0,0:54:58.64,0:55:00.44,Default,,0,0,0,,we state an invariant like this.
-Dialogue: 0,0:55:01.40,0:55:04.56,Default,,0,0,0,,We are either locked or unlocked,
-Dialogue: 0,0:55:04.56,0:55:05.84,Default,,0,0,0,,in the latter case
+Dialogue: 0,0:54:58.64,0:55:00.44,Default,,0,0,0,,we state an invariant like this:
+Dialogue: 0,0:55:01.40,0:55:04.56,Default,,0,0,0,,we are either locked or unlocked,
+Dialogue: 0,0:55:04.56,0:55:05.84,Default,,0,0,0,,and in the latter case
 Dialogue: 0,0:55:05.84,0:55:08.76,Default,,0,0,0,,the invariant itself holds the assertion P.
 Dialogue: 0,0:55:11.40,0:55:14.92,Default,,0,0,0,,Now in our program\N logic with weak memory,
-Dialogue: 0,0:55:14.92,0:55:16.56,Default,,0,0,0,,P is subjective,
+Dialogue: 0,0:55:14.92,0:55:16.56,Default,,0,0,0,,P may be subjective,
 Dialogue: 0,0:55:16.56,0:55:20.00,Default,,0,0,0,,but everything in the\N invariant has to be objective.
 Dialogue: 0,0:55:20.00,0:55:24.84,Default,,0,0,0,,So the invariant we\N state instead is that one.
 Dialogue: 0,0:55:27.28,0:55:28.52,Default,,0,0,0,,In fact,
-Dialogue: 0,0:55:28.52,0:55:31.60,Default,,0,0,0,,it is the same as in your\N old separation logic,
+Dialogue: 0,0:55:28.52,0:55:31.60,Default,,0,0,0,,it is the same as in\N usual separation logic,
 Dialogue: 0,0:55:31.60,0:55:33.00,Default,,0,0,0,,but we add views.
 Dialogue: 0,0:55:33.00,0:55:34.92,Default,,0,0,0,,To remain objective,
-Dialogue: 0,0:55:34.92,0:55:36.24,Default,,0,0,0,,we make it explicit,
+Dialogue: 0,0:55:34.92,0:55:36.24,Default,,0,0,0,,we make it explicit
 Dialogue: 0,0:55:36.24,0:55:39.12,Default,,0,0,0,,at which view we have P,
-Dialogue: 0,0:55:39.12,0:55:41.28,Default,,0,0,0,,and we say that if it is the same view,
-Dialogue: 0,0:55:41.28,0:55:43.00,Default,,0,0,0,,as is stored in our case.
+Dialogue: 0,0:55:39.12,0:55:41.28,Default,,0,0,0,,and we say that it is the same view
+Dialogue: 0,0:55:41.28,0:55:43.00,Default,,0,0,0,,as is stored in lk.
 Dialogue: 0,0:55:43.92,0:55:45.24,Default,,0,0,0,,In other words,
-Dialogue: 0,0:55:45.24,0:55:48.56,Default,,0,0,0,,P holds in the eyes of whoever,
+Dialogue: 0,0:55:45.24,0:55:48.56,Default,,0,0,0,,P holds in the eyes of whoever
 Dialogue: 0,0:55:48.56,0:55:50.12,Default,,0,0,0,,last released the lock.
-Dialogue: 0,0:55:52.44,0:55:55.56,Default,,0,0,0,,So that P@U in the invariants,
-Dialogue: 0,0:55:55.56,0:55:57.36,Default,,0,0,0,,obviously allows to transfer,
+Dialogue: 0,0:55:52.44,0:55:55.56,Default,,0,0,0,,So that "P at U" in the invariant
+Dialogue: 0,0:55:55.56,0:55:57.36,Default,,0,0,0,,obviously allows to transfer
 Dialogue: 0,0:55:57.36,0:55:59.80,Default,,0,0,0,,the objective part of P,
-Dialogue: 0,0:55:59.80,0:56:01.52,Default,,0,0,0,,where the atomic location itself,
+Dialogue: 0,0:55:59.80,0:56:01.52,Default,,0,0,0,,while the atomic location itself
 Dialogue: 0,0:56:01.52,0:56:05.36,Default,,0,0,0,,allows to transfer the\N subjective part of P.
 Dialogue: 0,0:56:10.48,0:56:13.52,Default,,0,0,0,,So that was the proof of the spin lock.
 Dialogue: 0,0:56:13.52,0:56:14.96,Default,,0,0,0,,And in addition to this example,
-Dialogue: 0,0:56:14.96,0:56:17.44,Default,,0,0,0,,we did more case studies with\N different kinds of locks.
-Dialogue: 0,0:56:17.44,0:56:20.60,Default,,0,0,0,,Like algorithms for mutual exclusion,
+Dialogue: 0,0:56:14.96,0:56:17.44,Default,,0,0,0,,we did more case studies with\N different kinds of locks
+Dialogue: 0,0:56:17.44,0:56:20.60,Default,,0,0,0,,and algorithms for mutual exclusion,
 Dialogue: 0,0:56:20.60,0:56:21.96,Default,,0,0,0,,and in all of these examples,
 Dialogue: 0,0:56:21.96,0:56:25.28,Default,,0,0,0,,we have been experiencing the same pattern
 Dialogue: 0,0:56:25.28,0:56:30.40,Default,,0,0,0,,of sprinkling views over our invariants.
-Dialogue: 0,0:56:30.40,0:56:33.72,Default,,0,0,0,,So our general method\N for proving correctness,
+Dialogue: 0,0:56:30.40,0:56:33.72,Default,,0,0,0,,So a general method\N for proving correctness
 Dialogue: 0,0:56:33.72,0:56:36.00,Default,,0,0,0,,of a concurrent data structure,
 Dialogue: 0,0:56:36.00,0:56:37.88,Default,,0,0,0,,is to start by reasoning
 Dialogue: 0,0:56:37.88,0:56:40.56,Default,,0,0,0,,as if we had a sequentially\N consistent model,
-Dialogue: 0,0:56:40.56,0:56:43.24,Default,,0,0,0,,expressing the invariant in the usual
-Dialogue: 0,0:56:43.24,0:56:45.04,Default,,0,0,0,,concurrent sequential logic.
-Dialogue: 0,0:56:45.04,0:56:49.00,Default,,0,0,0,,Then identifying where\N synchronization happens,
+Dialogue: 0,0:56:40.56,0:56:43.24,Default,,0,0,0,,express the invariant in the usual
+Dialogue: 0,0:56:43.24,0:56:45.04,Default,,0,0,0,,concurrent separation logic.
+Dialogue: 0,0:56:45.04,0:56:49.00,Default,,0,0,0,,Then identify where\N synchronization happens,
 Dialogue: 0,0:56:49.00,0:56:51.08,Default,,0,0,0,,and make it explicit by adding views.
-Dialogue: 0,0:56:55.08,0:56:57.08,Default,,0,0,0,,To sum up I have presented\N a program logic,
-Dialogue: 0,0:56:57.08,0:56:58.88,Default,,0,0,0,,for OCaml,
+Dialogue: 0,0:56:55.08,0:56:57.08,Default,,0,0,0,,To sum up I have presented\N a program logic
+Dialogue: 0,0:56:57.08,0:56:58.88,Default,,0,0,0,,for Multicore OCaml,
 Dialogue: 0,0:56:58.88,0:57:01.72,Default,,0,0,0,,based on isolating\N subjectivity into views.
 Dialogue: 0,0:57:01.72,0:57:04.64,Default,,0,0,0,,I argued that this logic enables concise
-Dialogue: 0,0:57:04.64,0:57:08.12,Default,,0,0,0,,and natural reasoning of\N how threads synchronize.
+Dialogue: 0,0:57:04.64,0:57:08.12,Default,,0,0,0,,and natural reasoning on\N how threads synchronize.
 Dialogue: 0,0:57:09.12,0:57:10.36,Default,,0,0,0,,There is more in the paper,
 Dialogue: 0,0:57:10.36,0:57:13.72,Default,,0,0,0,,namely how the logic is realized,
 Dialogue: 0,0:57:13.72,0:57:15.92,Default,,0,0,0,,by building on top of a lower-level logic.
 Dialogue: 0,0:57:17.76,0:57:19.88,Default,,0,0,0,,And we also have more case studies.
 Dialogue: 0,0:57:21.48,0:57:24.24,Default,,0,0,0,,This entire work is mechanized\N in the Coq proof assistant,
-Dialogue: 0,0:57:24.24,0:57:27.12,Default,,0,0,0,,using the Iris logic framework.
+Dialogue: 0,0:57:24.24,0:57:27.12,Default,,0,0,0,,using the Iris separation logic framework.
 Dialogue: 0,0:57:27.12,0:57:29.68,Default,,0,0,0,,So we have a verified proof of soundness,
-Dialogue: 0,0:57:29.68,0:57:32.76,Default,,0,0,0,,and an entire language with\N which we can write programs
-Dialogue: 0,0:57:32.76,0:57:36.12,Default,,0,0,0,,and prove them correct using\N Hoare logic.
+Dialogue: 0,0:57:29.68,0:57:32.76,Default,,0,0,0,,and a toy language with\N which we can write programs
+Dialogue: 0,0:57:32.76,0:57:36.12,Default,,0,0,0,,and prove them correct using\N our program logic.
 Dialogue: 0,0:57:37.64,0:57:38.80,Default,,0,0,0,,And in the future,
 Dialogue: 0,0:57:38.80,0:57:41.68,Default,,0,0,0,,we would like to verify\N even more data structures.
-Dialogue: 0,0:57:41.68,0:57:45.08,Default,,0,0,0,,Thus so we would like to\N investigate data races,
-Dialogue: 0,0:57:45.08,0:57:47.88,Default,,0,0,0,,because data races are currently\N not supported in logic.
-Dialogue: 0,0:57:49.24,0:57:52.48,Default,,0,0,0,,Even though the underlying memory model,
+Dialogue: 0,0:57:41.68,0:57:45.08,Default,,0,0,0,,Also we would like to\N investigate data races,
+Dialogue: 0,0:57:45.08,0:57:47.88,Default,,0,0,0,,because data races are currently\N not supported in logic,
+Dialogue: 0,0:57:49.24,0:57:52.48,Default,,0,0,0,,even though the underlying memory model
 Dialogue: 0,0:57:52.48,0:57:54.64,Default,,0,0,0,,gives a few guarantees about them.
-Dialogue: 0,0:57:56.00,0:57:57.28,Default,,0,0,0,,Thank you for your attention.
-Dialogue: 0,0:57:57.28,0:57:59.24,Default,,0,0,0,,And if you have seen on previous slides,
-Dialogue: 0,0:57:59.24,0:58:01.84,Default,,0,0,0,,you hold the right to\N ask questions though.
+Dialogue: 0,0:57:56.00,0:57:57.28,Default,,0,0,0,,Thank you for your attention,
+Dialogue: 0,0:57:57.28,0:57:59.24,Default,,0,0,0,,and if you have seen all previous slides,
+Dialogue: 0,0:57:59.24,0:58:01.84,Default,,0,0,0,,you hold the right to\N ask questions now.
 Dialogue: 0,0:58:03.24,0:58:05.48,Default,,0,0,0,,(clapping)
-Dialogue: 0,0:58:12.04,0:58:14.16,Default,,0,0,0,,STEPHANIE: Thank you Glenn.
+Dialogue: 0,0:58:12.04,0:58:14.16,Default,,0,0,0,,STEPHANIE: Thank you Glen.
 Dialogue: 0,0:58:14.16,0:58:16.04,Default,,0,0,0,,If you are watching this talk live,
 Dialogue: 0,0:58:16.04,0:58:17.92,Default,,0,0,0,,as an ICFP participant,
 Dialogue: 0,0:58:17.92,0:58:20.96,Default,,0,0,0,,please look to see if there\N is a Q&A session available,


### PR DESCRIPTION
I have introduced non-ASCII latin characters, UTF-8-encoded (lines 679 to 682: `é`, `É` and `ç`), replace them with their base letter if that is a problem.